### PR TITLE
Add JWT validation leeway in token decoding

### DIFF
--- a/application/idp_client/service.py
+++ b/application/idp_client/service.py
@@ -37,7 +37,9 @@ class IdpService:
             logger.error(f'No session found based on id {state}')
             return 'Bad request, No session found based on id ' + state, 400
 
-        hti_launch_token = pyjwt.decode(oauth2_session.launch, options={"verify_signature": False})
+        hti_launch_token = pyjwt.decode(oauth2_session.launch,
+                                        options={"verify_signature": False},
+                                        leeway=current_app.config.get('JWT_VALIDATION_LEEWAY', 10))
         logger.info(f'[{oauth2_session.id}] Consuming idp oidc code for user {hti_launch_token["sub"]}')
 
         if 'X-Trace-Id' not in trace_headers:
@@ -59,7 +61,9 @@ class IdpService:
             logger.error(f'[{oauth2_session.id}] no id_token found')
             return 'Bad request, no id_token found', 400
 
-        id_token = pyjwt.decode(encoded_id_token, options={"verify_signature": False})  # TODO: Verify signature
+        id_token = pyjwt.decode(encoded_id_token,
+                                options={"verify_signature": False},
+                                leeway=current_app.config.get('JWT_VALIDATION_LEEWAY', 10))  # TODO: Verify signature
 
         if oauth2_session.identity_provider:
             identity_provider: IdentityProvider = IdentityProvider.query.filter_by(id=oauth2_session.identity_provider).first()

--- a/application/oauth_server/views.py
+++ b/application/oauth_server/views.py
@@ -166,7 +166,9 @@ def create_blueprint() -> Blueprint:
             if not token:
                 return 'Bad Request, required field token missing', 400
 
-            unverified_decoded_jwt = pyjwt.decode(token, options={"verify_signature": False})
+            unverified_decoded_jwt = pyjwt.decode(token,
+                                                  options={"verify_signature": False},
+                                                  leeway=current_app.config.get('JWT_VALIDATION_LEEWAY', 10))
             iss = unverified_decoded_jwt.get('iss')
             if not iss:
                 return jsonify({'active': False})

--- a/instance/config.py
+++ b/instance/config.py
@@ -63,6 +63,8 @@ OIDC_JWT_PUBLIC_KEY = envget_str('OIDC_JWT_PUBLIC_KEY', '')
 OIDC_JWT_PRIVATE_KEY = envget_str('OIDC_JWT_PRIVATE_KEY', '')
 OIDC_JWT_EXP_TIME_ACCESS_TOKEN = envget_int('OIDC_JWT_EXP_TIME_ACCESS_TOKEN', 300)
 
+JWT_VALIDATION_LEEWAY = envget_int('JWT_VALIDATION_LEEWAY', 10)
+
 # IdP is used to retrieve the id_token of the logged-in user
 IDP_AUTHORIZE_ENDPOINT = envget_str('IDP_AUTHORIZE_ENDPOINT', 'https://iam.koppeltaal.headease.nl/realms/Koppeltaal2/protocol/openid-connect/auth')
 IDP_TOKEN_ENDPOINT = envget_str('IDP_TOKEN_ENDPOINT', 'https://iam.koppeltaal.headease.nl/realms/Koppeltaal2/protocol/openid-connect/token')

--- a/test/test_oauth_flows.py
+++ b/test/test_oauth_flows.py
@@ -40,7 +40,8 @@ def testing_app(server_key: Key):
                       'SMART_BACKEND_SERVICE_DEVICE_ID': 'Device/' + str(uuid4()),
                       'OIDC_SMART_CONFIG_SIGNING_ALGS': ["RS384", "ES384", "RS512"],
                       'OIDC_JWT_PUBLIC_KEY': server_key.as_pem(),
-                      'OIDC_JWT_PRIVATE_KEY': private_key_bytes})
+                      'OIDC_JWT_PRIVATE_KEY': private_key_bytes,
+                      'JWT_VALIDATION_LEEWAY': 0})
     with app.test_client() as client:
         with app.app_context():
             yield client


### PR DESCRIPTION
JTW decoding now includes an additional 'leeway' parameter in application/oauth_server/views.py, test/test_oauth_flows.py, and other related files. The JWT_VALIDATION_LEEWAY configuration has also been added to the config.py file. These changes provide a margin for potential clock skew when validating the timestamp claims (`iat`, `nbf`, `exp`) of the JWT.