### PR TITLE
Add `fhirUser` field to OAuth token payload

### DIFF
--- a/application/fhir_logging_client/service.py
+++ b/application/fhir_logging_client/service.py
@@ -87,7 +87,8 @@ class FhirLoggingService:
                         "coding":  [
                             {
                                 "system": "http://dicom.nema.org/resources/ontology/DCM",
-                                "code": "110153"
+                                "code": "110153",
+                                "display": "Source Role ID"
                             }
                         ]
                     },
@@ -103,6 +104,11 @@ class FhirLoggingService:
                 "observer": {
                     "reference": f"Device/{current_app.config['SMART_BACKEND_SERVICE_DEVICE_ID']}",
                     "type": "Device"
+                },
+                "type" : {
+                  "system": "http://terminology.hl7.org/CodeSystem/security-source-type",
+                  "code": "6",
+                  "display": "Security Server"
                 }
             },
             "entity":  [

--- a/application/oauth_server/service.py
+++ b/application/oauth_server/service.py
@@ -51,7 +51,8 @@ class TokenService:
         return self._get_jwt_token(current_app.config['OIDC_JWT_EXP_TIME_ACCESS_TOKEN'],
                                    oauth2_token.client_id,
                                    sub=oauth2_token.subject,
-                                   azp=oauth2_token.client_id)
+                                   azp=oauth2_token.client_id,
+                                   fhirUser=oauth2_token.subject)
 
     def get_access_token(self, oauth2_token: Oauth2Token, scope: str) -> str:
         return self._get_jwt_token(current_app.config['OIDC_JWT_EXP_TIME_ACCESS_TOKEN'], 'fhir-server',
@@ -71,7 +72,7 @@ class TokenService:
         return str(uuid4())
 
     def _get_jwt_token(self, expiry: int, aud: str, type: str = None, sub: str = None, email: str = None,
-                       given_name: str = None, family_name: str = None, scope: str = None, azp: str = None) -> str:
+                       given_name: str = None, family_name: str = None, scope: str = None, azp: str = None, fhirUser: str = None) -> str:
         private_key, public_key = keypair_service.get_keypair()
         now = get_timestamp_now()
         payload = {
@@ -87,6 +88,9 @@ class TokenService:
 
         if sub is not None:
             payload['sub'] = sub
+
+        if fhirUser is not None:
+            payload['fhirUser'] = fhirUser
 
         if email is not None:
             payload['email'] = email


### PR DESCRIPTION
Included `fhirUser` in the JWT generation process to provide additional context about the FHIR user. Updated the `_get_jwt_token` method and payload logic to support this new attribute.